### PR TITLE
chore: use `throws` and `rejects` assertions

### DIFF
--- a/test/server.js
+++ b/test/server.js
@@ -84,23 +84,17 @@ t.test('redactThrow', async t => {
       throw badError
     }
     const safeHandler = redactThrow(handler)
-    try {
-      await safeHandler()
-      t.fail('should throw')
-    } catch (goodError) {
-      t.same(goodError.sensitive, undefined, 'should not have sensitive field')
-    }
-  })
-  t.test('invalid argument not function', async t => {
-    try {
-      redactThrow('hello world')
-      t.fail('should throw')
-    } catch (error) {
-      t.same(error.message, 'redactThrow expects a function', 'should throw with correct message')
-    }
+
+    await t.rejects(safeHandler, { sensitive: undefined }, 'should not have sensitive field')
   })
 
-  t.test('ensures args are passed down', async t => {
+  await t.test('invalid argument not function', async t => {
+    t.throws(() => {
+      redactThrow('hello world')
+    }, { message: 'redactThrow expects a function' }, 'should throw with correct message')
+  })
+
+  await t.test('ensures args are passed down', async t => {
     const handler = async (a, b, c) => {
       if (a !== 1) {
         throw new Error('a is not 1')


### PR DESCRIPTION
<!-- What / Why -->
<!-- Describe the request in detail. What it does and why it's being changed. -->

When testing that a function throws an error, it's easy to forget to include the `fail` assertion in the try block, and end up with a test that verifies nothing. I find `throws` and `rejects` assertions to be less error prone, and try to use them instead of assertions in a catch block.

Caveat: Unfortunately with tap 16, you can supply an object for comparison with the thrown error, but can't run arbitrary assertions. `throws` and `rejects` return the thrown error in newer versions of tap.

## References
<!-- Examples:
  Related to #0
  Depends on #0
  Blocked by #0
  Fixes #0
  Closes #0
-->
